### PR TITLE
Add shopify api payments tests

### DIFF
--- a/Shopify.xcodeproj/project.pbxproj
+++ b/Shopify.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		614B4DB8207E406C002A88E5 /* ShopifyAPITestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B4DB7207E406C002A88E5 /* ShopifyAPITestHelper.swift */; };
 		6179160F2080A93300D447F9 /* ShopifyAPICategoriesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6179160D2080A93200D447F9 /* ShopifyAPICategoriesSpec.swift */; };
 		617916102080A93300D447F9 /* ShopifyAPIProductsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6179160E2080A93300D447F9 /* ShopifyAPIProductsSpec.swift */; };
+		617916122080BE9200D447F9 /* ShopifyAPIPaymentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617916112080BE9200D447F9 /* ShopifyAPIPaymentsSpec.swift */; };
 		8E283D3220400BED0041E432 /* Shopify.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ED91F9F20344DDE00E9692A /* Shopify.framework */; };
 		8E3265E02037239A00B3C50E /* Countries.json in Resources */ = {isa = PBXBuildFile; fileRef = 8E3265DF2037239A00B3C50E /* Countries.json */; };
 		8ED91FA420344DDE00E9692A /* Shopify.h in Headers */ = {isa = PBXBuildFile; fileRef = 8ED91FA220344DDE00E9692A /* Shopify.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -156,6 +157,7 @@
 		614B4DB7207E406C002A88E5 /* ShopifyAPITestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopifyAPITestHelper.swift; sourceTree = "<group>"; };
 		6179160D2080A93200D447F9 /* ShopifyAPICategoriesSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShopifyAPICategoriesSpec.swift; sourceTree = "<group>"; };
 		6179160E2080A93300D447F9 /* ShopifyAPIProductsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShopifyAPIProductsSpec.swift; sourceTree = "<group>"; };
+		617916112080BE9200D447F9 /* ShopifyAPIPaymentsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopifyAPIPaymentsSpec.swift; sourceTree = "<group>"; };
 		89727AFB067484CDB69B4F06 /* Pods-Shopify-ShopifyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shopify-ShopifyTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shopify-ShopifyTests/Pods-Shopify-ShopifyTests.debug.xcconfig"; sourceTree = "<group>"; };
 		8E283D2D20400BED0041E432 /* ShopifyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShopifyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E283D3120400BED0041E432 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -325,6 +327,7 @@
 				6179160D2080A93200D447F9 /* ShopifyAPICategoriesSpec.swift */,
 				6179160E2080A93300D447F9 /* ShopifyAPIProductsSpec.swift */,
 				0B4A59BE207F9C6A0091DAAB /* ShopifyAPIOrdersSpec.swift */,
+				617916112080BE9200D447F9 /* ShopifyAPIPaymentsSpec.swift */,
 				614B4DB1207CE931002A88E5 /* ShopifyAPIShopSpec.swift */,
 			);
 			path = ShopifyAPI;
@@ -675,6 +678,7 @@
 			files = (
 				0BA5DC392076040700668C99 /* ShopifyCheckoutAdapterSpec.swift in Sources */,
 				0B4A59BD207F79A10091DAAB /* ShopifyAPIBaseSpec.swift in Sources */,
+				617916122080BE9200D447F9 /* ShopifyAPIPaymentsSpec.swift in Sources */,
 				614B4DB8207E406C002A88E5 /* ShopifyAPITestHelper.swift in Sources */,
 				0BA5DC4920765E2500668C99 /* ShopifyProductAdapterSpec.swift in Sources */,
 				614B4DB5207D0EAB002A88E5 /* GraphClientMock.swift in Sources */,

--- a/ShopifyTests/API/ShopifyAPI/ShopifyAPIPaymentsSpec.swift
+++ b/ShopifyTests/API/ShopifyAPI/ShopifyAPIPaymentsSpec.swift
@@ -1,0 +1,227 @@
+//
+//  ShopifyAPIPaymentsSpec.swift
+//  ShopifyTests
+//
+//  Created by Evgeniy Antonov on 4/13/18.
+//  Copyright © 2018 RubyGarage. All rights reserved.
+//
+
+import MobileBuySDK
+import Nimble
+import Quick
+import ShopApp_Gateway
+
+class ShopifyAPIPaymentsSpec: ShopifyAPIBaseSpec {
+    override func spec() {
+        super.spec()
+        
+        describe("when create chackout called") {
+            context("if success") {
+                it("should return success response") {
+                    self.clientMock.returnedMutationResponse = try! Storefront.Mutation(fields: ["checkoutCreate": ["checkout": ShopifyAPITestHelper.checkout]])
+                    
+                    self.shopifyAPI.createCheckout(cartProducts: []) { (checkout, error) in
+                        expect(checkout?.id) == ShopifyAPITestHelper.checkout["id"] as? String
+                        expect(error).to(beNil())
+                    }
+                }
+            }
+            
+            context("if error occured") {
+                context("because of user error") {
+                    it("should return user error") {
+                        self.clientMock.returnedMutationResponse = try! Storefront.Mutation(fields: ["checkoutCreate": ["checkout": NSNull(),
+                                                                                                                        "userErrors": ShopifyAPITestHelper.checkoutCreateUserErrors]])
+                        
+                        self.shopifyAPI.createCheckout(cartProducts: []) { (checkout, error) in
+                            expect(checkout).to(beNil())
+                            expect(error?.errorMessage) == "Error message"
+                        }
+                    }
+                }
+                
+                context("because of content error") {
+                    it("should return error") {
+                        self.clientMock.returnedMutationResponse = try! Storefront.Mutation(fields: ["checkoutCreate": ["checkout": NSNull(),
+                                                                                                                        "userErrors": []]])
+                        
+                        self.shopifyAPI.createCheckout(cartProducts: []) { (checkout, error) in
+                            expect(checkout).to(beNil())
+                            expect(error is ContentError) == true
+                        }
+                    }
+                }
+            }
+        }
+        
+        describe("when get checkout called") {
+            context("if success") {
+                it("should return success response") {
+                    self.clientMock.returnedResponse = try! Storefront.QueryRoot(fields: ["node": ShopifyAPITestHelper.checkout])
+                    
+                    self.shopifyAPI.getCheckout(with: "id") { (checkout, error) in
+                        expect(checkout?.id) == ShopifyAPITestHelper.checkout["id"] as? String
+                        expect(error).to(beNil())
+                    }
+                }
+            }
+            
+            context("if error occured") {
+                context("because of server error") {
+                    it("should return error") {
+                        let errorExpectation: ErrorExpectation = { errorMessage in
+                            self.shopifyAPI.getCheckout(with: "id") { (checkout, error) in
+                                expect(checkout).to(beNil())
+                                expect(error?.errorMessage) == errorMessage
+                            }
+                        }
+                        
+                        self.expectError(in: errorExpectation)
+                    }
+                }
+                
+                context("because checkout nil and error didn't occure") {
+                    it("should return content error") {
+                        self.clientMock.returnedResponse = try! Storefront.QueryRoot(fields: ["node": NSNull()])
+                        
+                        self.shopifyAPI.getCheckout(with: "id") { (checkout, error) in
+                            expect(checkout).to(beNil())
+                            expect(error is ContentError) == true
+                        }
+                    }
+                }
+            }
+        }
+        
+        describe("when update shipping address called") {
+            context("if success") {
+                it("should return success response") {
+                    self.clientMock.returnedMutationResponse = try! Storefront.Mutation(fields: ["checkoutShippingAddressUpdate": ["checkout": ShopifyAPITestHelper.checkout]])
+                    
+                    self.shopifyAPI.updateShippingAddress(with: "CheckoutID", address: Address()) { (success, error) in
+                        expect(success) == true
+                        expect(error).to(beNil())
+                    }
+                }
+            }
+            
+            context("if user error occured") {
+                context("because of user error") {
+                    it("should return user error") {
+                        self.clientMock.returnedMutationResponse = try! Storefront.Mutation(fields: ["checkoutShippingAddressUpdate": ["checkout": ["shippingAddress": NSNull()],
+                                                                                                                                       "userErrors": ShopifyAPITestHelper.checkoutCreateUserErrors]])
+                        
+                        self.shopifyAPI.updateShippingAddress(with: "CheckoutID", address: Address()) { (success, error) in
+                            expect(success) == false
+                            expect(error?.errorMessage) == ShopifyAPITestHelper.checkoutCreateUserErrors.first!["message"] as? String
+                        }
+                    }
+                }
+                
+                context("because of content error") {
+                    it("should return content error") {
+                        let errorExpectation: ErrorExpectation = { _ in
+                            self.shopifyAPI.updateShippingAddress(with: "CheckoutID", address: Address()) { (success, error) in
+                                expect(success) == false
+                                expect(error is ContentError) == true
+                            }
+                        }
+                        
+                        self.expectError(in: errorExpectation)
+                    }
+                }
+            }
+        }
+        
+        describe("when get shipping rates called") {
+            context("if success") {
+                it("should return success response") {
+                    self.clientMock.returnedResponse = try! Storefront.QueryRoot(fields: ["node": ShopifyAPITestHelper.checkout])
+                    
+                    self.shopifyAPI.getShippingRates(with: "CheckoutID") { (rates, error) in
+                        expect(rates?.first?.title) == ShopifyAPITestHelper.shippingRate["title"] as? String
+                        expect(error).to(beNil())
+                    }
+                }
+            }
+            
+            context("if error occured") {
+                it("should return error") {
+                    let errorExpectation: ErrorExpectation = { _ in
+                        self.shopifyAPI.getShippingRates(with: "CheckoutID") { (rates, error) in
+                            expect(rates).to(beNil())
+                            expect(error is ContentError) == true
+                        }
+                    }
+                    
+                    self.expectError(in: errorExpectation)
+                }
+            }
+        }
+        
+        describe("when update checkout called") {
+            context("if success") {
+                it("should return success response") {
+                    self.clientMock.returnedMutationResponse = try! Storefront.Mutation(fields: ["checkoutShippingLineUpdate": ["checkout": ShopifyAPITestHelper.checkout]])
+                    
+                    self.shopifyAPI.updateCheckout(with: ShippingRate(), checkoutId: "CheckoutID") { (checkout, error) in
+                        expect(checkout?.id) == ShopifyAPITestHelper.checkout["id"] as? String
+                        expect(error).to(beNil())
+                    }
+                }
+            }
+            
+            context("if error occured") {
+                context("because of server error") {
+                    it("should return content error") {
+                        let errorExpectation: ErrorExpectation = { _ in
+                            self.shopifyAPI.updateCheckout(with: ShippingRate(), checkoutId: "CheckoutID") { (checkout, error) in
+                                expect(checkout).to(beNil())
+                                expect(error is ContentError) == true
+                            }
+                        }
+                        
+                        self.expectError(in: errorExpectation)
+                    }
+                }
+                
+                context("because of response and error doesn't exist") {
+                    it("should return content error") {
+                        self.clientMock.returnedMutationResponse = try! Storefront.Mutation(fields: ["checkoutShippingLineUpdate": ["checkout": NSNull()]])
+                        
+                        self.shopifyAPI.updateCheckout(with: ShippingRate(), checkoutId: "CheckoutID") { (checkout, error) in
+                            expect(checkout).to(beNil())
+                            expect(error is ContentError) == true
+                        }
+                    }
+                }
+            }
+        }
+        
+        describe("when get shop currency called") {
+            context("if success") {
+                it("should return success response") {
+                    self.clientMock.returnedResponse = try! Storefront.QueryRoot(fields: ["shop": ["paymentSettings": ShopifyAPITestHelper.paymentSettings]])
+                    
+                    self.shopifyAPI.getShopCurrency() { (settings, error) in
+                        expect(settings?.currencyCode.rawValue) == ShopifyAPITestHelper.paymentSettings["currencyCode"] as? String
+                        expect(error).to(beNil())
+                    }
+                }
+            }
+            
+            context("if error occured") {
+                it("should return error") {
+                    let errorExpectation: ErrorExpectation = { _ in
+                        self.shopifyAPI.getShopCurrency() { (settings, error) in
+                            expect(settings).to(beNil())
+                            expect(error).toNot(beNil())
+                        }
+                    }
+                    
+                    self.expectError(in: errorExpectation)
+                }
+            }
+        }
+    }
+}

--- a/ShopifyTests/API/ShopifyAPI/ShopifyAPITestHelper.swift
+++ b/ShopifyTests/API/ShopifyAPI/ShopifyAPITestHelper.swift
@@ -107,6 +107,23 @@ struct ShopifyAPITestHelper {
                 "cursor": "Cursor"]
     }
 
+    static var checkout: [String: Any] {
+        return ["id": "CheckoutIdentifier",
+                "webUrl": "www.google.com",
+                "currencyCode": "Currency",
+                "subtotalPrice": "5",
+                "totalPrice": "5",
+                "shippingLine": shippingRate,
+                "shippingAddress": mailingAddress,
+                "lineItems": checkoutLineItems,
+                "availableShippingRates": availableShippingRates,
+                "__typename": "Checkout"]
+    }
+    
+    static var checkoutCreateUserErrors: [[String: Any]] {
+        return [["message": "Error message"]]
+    }
+    
     static var mailingAddress: [String: Any] {
         return ["id": "MailingAddressIdentifier",
                 "firstName": "First",
@@ -178,6 +195,35 @@ struct ShopifyAPITestHelper {
                 "images": images,
                 "options": options]
     }
+
+    static var checkoutLineItem: [String: Any] {
+        return ["id": "CheckoutLineItemIdentifier",
+                "variant": variant,
+                "quantity": 5]
+    }
+    
+    static var checkoutLineItemsEdges: [[String: Any]] {
+        return [["node": checkoutLineItem,
+                 "cursor": "Cursor"]]
+    }
+    
+    static var checkoutLineItems: [String: Any] {
+        return ["edges": checkoutLineItemsEdges]
+    }
+    
+    static var availableShippingRates: [String: Any] {
+        return ["shippingRates": shippingRates]
+    }
+    
+    static var shippingRates: [[String: Any]] {
+        return [shippingRate]
+    }
+    
+    static var shippingRate: [String: Any] {
+        return ["title": "Title",
+                "price": "5",
+                "handle": "Handle"]
+    }
     
     static var variant: [String: Any] {
         return ["id": "VariantIdentifier",
@@ -241,5 +287,53 @@ struct ShopifyAPITestHelper {
     
     static var customerAccessTokenCreate: [String: Any] {
         return ["customerAccessTokenCreate": customerAccessToken]
+    }
+
+    static var variantImage: [String: Any] {
+        return ["id": "VariantImageIdentifier",
+                "src": "Source",
+                "altText": "Text"]
+    }
+    
+    static var selectedOptions: [[String: Any]] {
+        return [selectedOption]
+    }
+    
+    static var selectedOption: [String: Any] {
+        return ["name": "Name",
+                "value": "Value"]
+    }
+    
+    static var variantProduct: [String: Any] {
+        return ["id": "VariantProductIdentifier",
+                "images": images,
+                "options": options]
+    }
+    
+    static var imagesEdges: [[String: Any]] {
+        return [["node": image,
+                 "cursor": "Cursor"]]
+    }
+    
+    static var images: [String: Any] {
+        return ["edges": imagesEdges]
+    }
+    
+    static var option: [String: Any] {
+        return ["id": "OptionIdentifier",
+                "name": "Name",
+                "values": values]
+    }
+    
+    static var options: [[String: Any]] {
+        return [option]
+    }
+    
+    static var values: [String] {
+        return ["Value"]
+    }
+    
+    static var paymentSettings: [String: Any] {
+           return ["currencyCode": "USD"]
     }
 }

--- a/ShopifyTests/API/ShopifyAPI/ShopifyAPITestHelper.swift
+++ b/ShopifyTests/API/ShopifyAPI/ShopifyAPITestHelper.swift
@@ -288,50 +288,6 @@ struct ShopifyAPITestHelper {
     static var customerAccessTokenCreate: [String: Any] {
         return ["customerAccessTokenCreate": customerAccessToken]
     }
-
-    static var variantImage: [String: Any] {
-        return ["id": "VariantImageIdentifier",
-                "src": "Source",
-                "altText": "Text"]
-    }
-    
-    static var selectedOptions: [[String: Any]] {
-        return [selectedOption]
-    }
-    
-    static var selectedOption: [String: Any] {
-        return ["name": "Name",
-                "value": "Value"]
-    }
-    
-    static var variantProduct: [String: Any] {
-        return ["id": "VariantProductIdentifier",
-                "images": images,
-                "options": options]
-    }
-    
-    static var imagesEdges: [[String: Any]] {
-        return [["node": image,
-                 "cursor": "Cursor"]]
-    }
-    
-    static var images: [String: Any] {
-        return ["edges": imagesEdges]
-    }
-    
-    static var option: [String: Any] {
-        return ["id": "OptionIdentifier",
-                "name": "Name",
-                "values": values]
-    }
-    
-    static var options: [[String: Any]] {
-        return [option]
-    }
-    
-    static var values: [String] {
-        return ["Value"]
-    }
     
     static var paymentSettings: [String: Any] {
            return ["currencyCode": "USD"]


### PR DESCRIPTION
Methods `pay(with card)`, `setupApplePay()` and `getCountries()` would be implemented in next PR